### PR TITLE
Feat: Atom support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ A minimalist RSS feed client for your terminal.
 
 - Uses SQLite as the backing database, so you may interface with your data however you like.
 
-**WORK IN PROGRESS**
-
 ## Installing
 
 Requires _cargo_ and _rustc_
@@ -65,3 +63,7 @@ For both of these the sqlite file is at: `<LOCATION>/corkboard/corkdb`.
 
 Use a custom database path by setting the variable (in your shell environment): `$CORKDB`
 
+## Note on Atom support
+
+Atom is "partially" supported, in the sense that one may subscribe to Atom feeds as if they were RSS feeds,
+however, no features specific to Atom are supported.

--- a/assets/atom1.rss
+++ b/assets/atom1.rss
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+	<title>Sample Atom feed</title>
+	<link rel="self" href="http://localhost"/>
+	<link rel="alternate" href="http://localhost/IGNORE"/>
+	<updated>2025-01-25T19:03:00</updated>
+	<id>http://localhost</id>
+</feed>

--- a/assets/atom2.rss
+++ b/assets/atom2.rss
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+	<title>Another Atom feed</title>
+	<link rel="self" href="http://localhost"/>
+	<link rel="alternate" href="http://localhost/IGNORE"/>
+	<updated>2025-01-25T19:03:00</updated>
+	<id>http://localhost</id>
+	<entry>
+		<title>First article</title>
+		<link rel="alternate" href="http://localhost/first"></link>
+		<id>http://localhost/first</id>
+		<updated>2025-01-24T19:03:00</updated>
+	</entry>
+	<entry>
+		<title>Second article</title>
+		<link rel="alternate" href="http://localhost/second"></link>
+		<id>http://localhost/second</id>
+		<updated>2025-01-24T19:03:00</updated>
+	</entry>
+</feed>

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 //! (without being too intrusive with what hasn't been)
 //!
 //! ```text
-//! add <url>		<- Add a new RSS feed to the app.
+//! add <url>		<- Add a new RSS feed (or Atom) to the app.
 //! up				<- Update all feeds, show the new articles.
 //! mark <item>		<- Mark article/item as read.
 //! new				<- Show all articles that haven't been marked.

--- a/src/xml_handler.rs
+++ b/src/xml_handler.rs
@@ -1,26 +1,26 @@
 //! Parsing the RSS XML into structs we can handle
 
 use chrono::{DateTime, offset::Utc};
-use roxmltree::{Node};
+use roxmltree::Node;
 use std::{fmt, error};
 use crate::rss::{Channel, Item};
 
 #[derive(Debug)]
-enum XmlError {
-	RSSTagIsNotRoot,
+pub enum XmlError {
+	UnknownFormat,
+	ParserFailed,
 	NoChannelTag,
 	NoTitle,
-	NoLink,
-	_NoDesc
+	NoLink
 }
 impl fmt::Display for XmlError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		let err_string = match self {
-			XmlError::RSSTagIsNotRoot => "rss tag is not at the top of the xml passed",
+			XmlError::UnknownFormat => "Format of the XML passed is neither Atom nor RSS",
+			XmlError::ParserFailed => "Could not parse XML",
 			XmlError::NoChannelTag => "The channel tag was not found in the xml passed",
 			XmlError::NoTitle => "The title for the channel is not present in the xml passed",
 			XmlError::NoLink => "The link for the channel is not present in the xml passed",
-			_ => "xml error"
 		};
 
 		write!(f, "{}", err_string)
@@ -60,15 +60,8 @@ fn process_item(item_tag: &Node) -> Option<Item> {
 	Some(Item::new(title_or_description, link, pub_date))
 }
 
-/// Turns an xml string into a Channel struct, if the xml is misformed
-/// then an error is returned.
-pub fn xml_to_rss (xml_source: &str) -> anyhow::Result<Channel> {
-	let xml_tree = roxmltree::Document::parse(xml_source)?;
-	let root = xml_tree.root_element();//RSS element
-	
-	if root.tag_name().name() != "rss" {
-		Err(XmlError::RSSTagIsNotRoot)?
-	}
+/// Parses an XML in RSS format into a Channel.
+fn parse_rss(root: Node) -> Result<Channel, XmlError> {
 	let channel_tag = get_named_child(&root, "channel")
 		.ok_or(XmlError::NoChannelTag)?;
 
@@ -100,3 +93,91 @@ pub fn xml_to_rss (xml_source: &str) -> anyhow::Result<Channel> {
 	})
 }
 
+
+/// Tries to find a direct child of the parent tag with the name _name_
+fn get_named_child_atom<'a>(parent: &Node<'a, 'a>, name: &str) -> Option<Node<'a, 'a>> {
+	//Maybe we should be normalizing the strings before comparing them
+	//We check the namespace to make sure we aren't getting content inteded for another
+	//kind of app, like atom readers
+	parent
+		.children()
+		.find(|c| c.tag_name().name() == name && c.tag_name().namespace() == Some("http://www.w3.org/2005/Atom"))
+}
+
+fn get_text_from_child_atom(parent: &Node, name: &str) -> Option<String> {
+	let borrowed = get_named_child_atom(parent, name)?.text()?;
+	Some(String::from(borrowed))
+}
+
+/// Parses a single _entry_ block in an atom feed
+fn process_atom_entry(entry: &Node) -> Option<Item> {
+	// Atom requires entries to have a title, no need to search for a description
+	// if one is not present
+	let title = get_text_from_child_atom(entry, "title")?;
+
+	let link = get_named_child_atom(entry, "link")
+		.and_then(|link_tag| link_tag.attribute("href"))
+		.and_then(|href| Some(href.to_string()) );
+
+	// This is less strict than the atom spec, since updated is necessary.
+	let pub_date = get_text_from_child_atom(entry, "updated")
+		.and_then(|date_s| DateTime::parse_from_rfc3339(&date_s).ok())
+		.and_then(|fixed_date| Some(DateTime::<Utc>::from(fixed_date)));
+
+	Some(Item::new(title, link, pub_date))
+}
+
+/// Parses an XML in Atom format into a Channel.
+fn parse_atom(root: Node) -> Result<Channel, XmlError> {
+	let title = get_text_from_child_atom(&root, "title")
+		.ok_or(XmlError::NoTitle)?;
+
+	//OBS: DECIDED TO REQUIRE LINK, THIS DOES NOT RESPECT ATOM'S SPEC.
+	//Also note that links work like _a_ tags in html.
+	let link:String = root.children()
+		.find(|c|
+			c.tag_name().name() == "link" &&
+			c.tag_name().namespace() == Some("http://www.w3.org/2005/Atom") &&
+			c.attribute("rel") == Some("self"))
+		.ok_or(XmlError::NoLink)?
+		.attribute("href")
+		.ok_or(XmlError::NoLink)?
+		.to_string();
+
+	//OBS: required by RSS spec, not by Atom
+	let description = String::new();
+
+	//Not absolutely confident that **all** viable strings (xml:xsd) will be
+	//correctly parsed by this.
+	let last_build_date:Option<DateTime<_>> = get_text_from_child_atom(&root, "updated")
+		.and_then(|date_s| DateTime::parse_from_rfc3339(&date_s).ok())
+		.and_then(|fixed_date| Some(DateTime::<Utc>::from(fixed_date)));
+
+	let items:Vec<Item> = root.children()
+		.filter(|c| c.tag_name().name() == "entry")
+		.flat_map(|i| process_atom_entry(&i))
+		.collect();
+
+	Ok(Channel {
+		title,
+		link,
+		description,
+		last_build_date,
+		items
+	})
+}
+
+/// Turns an xml string into a Channel struct.
+/// Works for both RSS & Atom, though most of Atom's features are ignored.
+/// If the xml is malformed/unparsable, an error is returned.
+pub fn xml_to_rss(xml_source: &str) -> Result<Channel, XmlError> {
+	let xml_tree = roxmltree::Document::parse(xml_source)
+		.map_err(|_| XmlError::ParserFailed )?;
+	let root = xml_tree.root_element();
+
+	match root.tag_name().namespace() {
+		Some("http://www.w3.org/2005/Atom") => parse_atom(root),
+		None if root.tag_name().name() == "rss" => parse_rss(root),
+		_ => Err(XmlError::UnknownFormat)
+	}
+}

--- a/tests/add-atom-test.rs
+++ b/tests/add-atom-test.rs
@@ -1,0 +1,30 @@
+//OBS: If we can succesfully add an Atom feed, then
+//we must necessarily be parsing it successfully
+
+use rusqlite::Connection;
+
+mod utils;
+use utils::*;
+
+#[test]
+fn add_atom_test() {
+	// Empty atom feed
+	ensure_new_database();
+	let mut first_sample = Miniserve::launch("./assets/atom1.rss", None);
+	let first_output = run_cork(&["add", "http://localhost:8080"]);
+	first_sample.kill();
+	assert!(first_output.status.success());
+	let db = Connection::open("corkdb").unwrap();
+	assert_eq!(count_channels(&db), 1);
+	assert_eq!(count_items(&db), 0);
+
+	// An atom feed with two entries
+	ensure_new_database();
+	let mut second_sample = Miniserve::launch("./assets/atom2.rss", None);
+	let second_output = run_cork(&["add", "http://localhost:8080"]);
+	second_sample.kill();
+	assert!(second_output.status.success());
+	let db = Connection::open("corkdb").unwrap();
+	assert_eq!(count_channels(&db), 1);
+	assert_eq!(count_items(&db), 2);
+}


### PR DESCRIPTION
Corkboard can now consume Atom feeds as if they were RSS feeds. Note that Atom's spec is not implemented fully (and in the case of the channel/feed link we are stricter since we do require it).

Wrote two sample atom feeds and an integration test _add-atom-test.rs_ for them.

Modified _xml_to_rss_ to decide which type of feed was fed to it before moving on to parsing. (So that users don't need to specify it themselves).